### PR TITLE
Dockerizing the code

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,6 +5,30 @@
 
 ## Deploy with Docker
 
+We create 2 images: one for the beacon, and one for a database, preloading some test data. 
+Run the following command in the current directory:
+
+	docker-compose build db
+	docker-compose build beacon
+	
+You can now instanciate the images into 2 containers. The docker-compose file contains the settings to create the network to attach the containers to, and a volume to store the data for the database. We are ready to boot up a test system, with:
+
+	docker-compose up -d
+	
+You are now ready to query the beacon on `localhost` (port 9075). For example:  
+
+* [localhost:9075/elixirbeacon/v1/beacon/](http://localhost:9075/elixirbeacon/v1/beacon/)
+* [localhost:9075/elixirbeacon/v1/beacon/query?referenceName=Y&start=2655179&referenceBases=G&alternateBases=A&assemblyId=GRCh37&datasetIds=1000genomes](http://localhost:9075/elixirbeacon/v1/beacon/query?referenceName=Y&start=2655179&referenceBases=G&alternateBases=A&assemblyId=GRCh37&datasetIds=1000genomes)
+* [localhost:9075/elixirbeacon/v1/beacon/query?referenceName=Y&start=2655179&referenceBases=G&alternateBases=A&assemblyId=GRCh37&datasetIds=1000genomes&includeDatasetResponses=HIT](http://localhost:9075/elixirbeacon/v1/beacon/query?referenceName=Y&start=2655179&referenceBases=G&alternateBases=A&assemblyId=GRCh37&datasetIds=1000genomes&includeDatasetResponses=HIT)
+
+
+The `-d` flag runs the containers _detached_, ie we get the prompt back. You can check the logs with:
+
+	docker-compose logs -f
+
+Tear down the system and remove the database volume, with:
+
+	docker-compose down -v
 
 ## Deploy manually
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     hostname: beacon-db
     container_name: beacon-db
     build: db
-    image: egarchive/beacon-db:latest
+    image: egarchive/elixir-beacon:db-latest
     volumes:
       - beacon-db:/beacon-db
     ports:
@@ -31,13 +31,14 @@ services:
   beacon:
     depends_on:
       - db
-    image: egarchive/beacon:elixir-test
+    build: ..
+    image: egarchive/elixir-beacon:latest
     hostname: beacon
     container_name: beacon
     volumes:
       - ./dev.properties:/beacon/application-dev.properties
     ports:
-      - "11111:9075"
+      - "9075:9075"
     networks:
       - beacon-priv
       - beacon-pub


### PR DESCRIPTION
This PR creates a docker version of the code, including a docker version of the database loading the test data.

This repository is already linked on Docker Hub to the `egarchive` organisation, creating automatically the `egarchive/elixir-beacon:{latest, vX.Y.Z}` images.